### PR TITLE
New version param for package ensure

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,10 +4,10 @@
 # This class will install wget - a tool used to download content from the web.
 #
 ################################################################################
-class wget {
+class wget($version='installed') {
   
   if $::operatingsystem != 'Darwin' {
-    package { "wget": ensure => installed }
+    package { "wget": ensure => $version }
   }
 }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -14,4 +14,14 @@ describe 'wget' do
     it { should contain_package('wget') }
   end
 
+  context 'no version specified' do
+    it { should contain_package('wget').with_ensure('installed') }
+  end
+
+  context 'version is 1.2.3' do
+    let(:params) { {:version => '1.2.3'} }
+
+    it { should contain_package('wget').with_ensure('1.2.3') }
+  end
+
 end


### PR DESCRIPTION
Allow a specific version to be passed into the Package[] resource. This
could also be used to remove the package. However it will continue to have
no effect on OSX platforms.

The value `installed` is now quoted, in reality this makes little
difference.
