### PR TITLE
Add option to download with user.

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -25,7 +25,11 @@ describe 'wget' do
   end
 
   describe 'wget::fetch' do
-    it { should contain_exec('wget-test').with_command('wget --no-verbose --output-document=/tmp/dest http://localhost/source') }
+    it { should contain_exec('wget-test').with({
+      'command' => 'wget --no-verbose --output-document=/tmp/dest http://localhost/source',
+      'user' => 'testuser'
+      })
+    }
   end
 
   describe 'wget::authfetch' do

--- a/spec/fixtures/manifests/site.pp
+++ b/spec/fixtures/manifests/site.pp
@@ -1,6 +1,7 @@
 wget::fetch { 'test':
   source      => 'http://localhost/source',
   destination => '/tmp/dest',
+  user        => 'testuser',
 }
 
 wget::authfetch { 'authtest':


### PR DESCRIPTION
I have added the option to run exec as a user, which makes the downloaded file belong to that user.

The functionality is very incomplete, but I did write a small test. I have no idea how to properly run those tests. Files kept going away and some other crazy stuff. It seems to me that there should be an option to change the user or not. Also the variable name kinda conflicts with the proxy user.

Works for my simple use case though.
