### PR TITLE
reworked for style

### DIFF
--- a/manifests/authfetch.pp
+++ b/manifests/authfetch.pp
@@ -1,0 +1,58 @@
+################################################################################
+# Definition: wget::authfetch
+#
+# This class will download files from the internet.  You may define a web proxy
+# using $::http_proxy if necessary. Username must be provided. And the user's
+# password must be stored in the password variable within the .wgetrc file.
+#
+################################################################################
+define wget::authfetch (
+  $source,
+  $destination,
+  $user,
+  $password = '',
+  $timeout  = '0',
+  $verbose  = false,
+) {
+
+  include wget
+
+  if $::http_proxy {
+    $environment = [ "HTTP_PROXY=${::http_proxy}", "http_proxy=${::http_proxy}", "WGETRC=/tmp/wgetrc-${name}" ]
+  }
+  else {
+    $environment = [ "WGETRC=/tmp/wgetrc-${name}" ]
+  }
+
+  $verbose_option = $verbose ? {
+    true  => '--verbose',
+    false => '--no-verbose'
+  }
+
+  case $::operatingsystem {
+    'Darwin': {
+      # This is to work around an issue with macports wget and out of date CA cert bundle.  This requires
+      # installing the curl-ca-bundle package like so:
+      #
+      # sudo port install curl-ca-bundle
+      $wgetrc_content = "password=${password}\nCA_CERTIFICATE=/opt/local/share/curl/curl-ca-bundle.crt\n"
+    }
+    default: {
+      $wgetrc_content = "password=${password}"
+    }
+  }
+
+  file { "/tmp/wgetrc-${name}":
+    owner   => 'root',
+    mode    => '0600',
+    content => $wgetrc_content,
+  } ->
+  exec { "wget-${name}":
+    command     => "wget ${verbose_option} --user=${user} --output-document=${destination} ${source}",
+    timeout     => $timeout,
+    unless      => "test -s ${destination}",
+    environment => $environment,
+    path        => '/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin',
+    require     => Class['wget'],
+  }
+}

--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -1,0 +1,40 @@
+################################################################################
+# Definition: wget::fetch
+#
+# This class will download files from the internet.  You may define a web proxy
+# using $http_proxy if necessary.
+#
+################################################################################
+define wget::fetch (
+  $source,
+  $destination,
+  $timeout = '0',
+  $verbose = false,
+) {
+
+  include wget
+
+  # using "unless" with test instead of "creates" to re-attempt download
+  # on empty files.
+  # wget creates an empty file when a download fails, and then it wouldn't try
+  # again to download the file
+  if $::http_proxy {
+    $environment = [ "HTTP_PROXY=${::http_proxy}", "http_proxy=${::http_proxy}" ]
+  } else {
+    $environment = []
+  }
+
+  $verbose_option = $verbose ? {
+    true  => '--verbose',
+    false => '--no-verbose'
+  }
+
+  exec { "wget-${name}":
+    command     => "wget ${verbose_option} --output-document=${destination} ${source}",
+    timeout     => $timeout,
+    unless      => "test -s ${destination}",
+    environment => $environment,
+    path        => '/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin',
+    require     => Class['wget'],
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,105 +4,13 @@
 # This class will install wget - a tool used to download content from the web.
 #
 ################################################################################
-class wget($version='installed') {
-  
+class wget (
+  $version = 'installed',
+) {
+
   if $::operatingsystem != 'Darwin' {
-    package { "wget": ensure => $version }
-  }
-}
-
-################################################################################
-# Definition: wget::fetch
-#
-# This class will download files from the internet.  You may define a web proxy
-# using $http_proxy if necessary.
-#
-################################################################################
-define wget::fetch($source,$destination,$timeout="0",$verbose=false,$redownload=false) {
-  include wget
-  # using "unless" with test instead of "creates" to re-attempt download
-  # on empty files.
-  # wget creates an empty file when a download fails, and then it wouldn't try
-  # again to download the file
-  if $::http_proxy {
-    $environment = [ "HTTP_PROXY=$::http_proxy", "http_proxy=$::http_proxy" ]
-  }
-  else {
-    $environment = []
-  }
-
-  $verbose_option = $verbose ? {
-    true  => "--verbose",
-    false => "--no-verbose"
-  }
-
-  $unless_test = $redownload ? {
-    true => "test",
-    false => "test -s $destination"
-  }
-  
-  exec { "wget-$name":
-    command => "wget $verbose_option --output-document=$destination $source",
-    timeout => $timeout,
-    unless => $unless_test,
-    environment => $environment,
-    path => "/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin",
-    require => Class[wget],
-  }
-}
-
-################################################################################
-# Definition: wget::authfetch
-#
-# This class will download files from the internet.  You may define a web proxy
-# using $http_proxy if necessary. Username must be provided. And the user's
-# password must be stored in the password variable within the .wgetrc file.
-#
-################################################################################
-define wget::authfetch($source,$destination,$user,$password="",$timeout="0",$verbose=false,$redownload=false) {
-  include wget
-  if $http_proxy {
-    $environment = [ "HTTP_PROXY=$http_proxy", "http_proxy=$http_proxy", "WGETRC=/tmp/wgetrc-$name" ]
-  }
-  else {
-    $environment = [ "WGETRC=/tmp/wgetrc-$name" ]
-  }
-
-  $verbose_option = $verbose ? {
-    true  => "--verbose",
-    false => "--no-verbose"
-  }
-
-  $unless_test = $redownload ? {
-    true => "test",
-    false => "test -s $destination"
-  }
-  
-  case $::operatingsystem {
-    'Darwin': {
-      # This is to work around an issue with macports wget and out of date CA cert bundle.  This requires 
-      # installing the curl-ca-bundle package like so:
-      #
-      # sudo port install curl-ca-bundle      
-      $wgetrc_content = "password=$password\nCA_CERTIFICATE=/opt/local/share/curl/curl-ca-bundle.crt\n"
-     } 
-     default: {
-      $wgetrc_content = "password=$password"
+    package { 'wget':
+      ensure => $version,
     }
   }
-  
-  file { "/tmp/wgetrc-$name":
-    owner => root,
-    mode => 600,
-    content => $wgetrc_content,
-  } ->
-  exec { "wget-$name":
-    command => "wget $verbose_option --user=$user --output-document=$destination $source",
-    timeout => $timeout,
-    unless => $unless_test,
-    environment => $environment,
-    path => "/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin",
-    require => Class[wget],
-  }
 }
-


### PR DESCRIPTION
Without this commit, the style does not comply with the Puppet Labs style guide. If you use puppet-lint in your pre-commit hooks then you would not be able to commit this code without this patch.
