### PR TITLE
Proper wget quote handling

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -43,7 +43,7 @@ define wget::fetch (
   }
 
   exec { "wget-${name}":
-    command     => "wget ${verbose_option}${nocheckcert_option} --output-document=${destination} ${source}",
+    command     => "wget ${verbose_option}${nocheckcert_option} --output-document=${destination} \"${source}\"",
     timeout     => $timeout,
     unless      => $unless_test,
     environment => $environment,


### PR DESCRIPTION
When using '&' in fetch url, it should be quoted for wget to correctly download the file. So I'm adding quotes around source parameter for wget command.
