### PR TITLE
fix compilation issues with newer versions of puppet

### DIFF
--- a/manifests/authfetch.pp
+++ b/manifests/authfetch.pp
@@ -15,7 +15,7 @@ define wget::authfetch (
   $verbose            = false,
   $redownload         = false,
   $nocheckcertificate = false,
-  $execuser           = 'root',
+  $execuser           = 'root'
 ) {
 
   include wget

--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -12,7 +12,7 @@ define wget::fetch (
   $verbose            = false,
   $redownload         = false,
   $nocheckcertificate = false,
-  $execuser           = 'root',
+  $execuser           = 'root'
 ) {
 
   include wget

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@
 #
 ################################################################################
 class wget (
-  $version = 'installed',
+  $version = 'installed'
 ) {
 
   if $::operatingsystem != 'Darwin' {


### PR DESCRIPTION
I am running v 2.7.22 and it didn't like the trailing commas.
