### PR TITLE
execuser should not default to root

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -12,7 +12,7 @@ define wget::fetch (
   $verbose            = false,
   $redownload         = false,
   $nocheckcertificate = false,
-  $execuser           = 'root',
+  $execuser           = undef,
 ) {
 
   include wget


### PR DESCRIPTION
This define is not usable when running puppet as non root because puppet raises "Only root can execute commands as other users" error.

So I think it's better to default to undef, which will work when launching puppet as regular user and defaults to root when running as root.
