### PR TITLE
Exec wget with default user when using cache_dir

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -85,7 +85,7 @@ define wget::fetch (
     timeout     => $timeout,
     unless      => $unless_test,
     environment => $environment,
-    user        => $execuser,
+    user        => $cache_dir ? { undef => $execuser, default => undef },
     path        => '/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin',
     require     => Class['wget'],
   }


### PR DESCRIPTION
When using the cache_dir attribute in wget::fetch we don't need to exec
wget with the execuser because only the destination file has to be owned
by it. In fact, in this case it's better to exec wget with the default
user (usually 'root') because the cache_dir may not be writeable by the
execuser.
