### PR TITLE
Update fetch.pp

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -25,7 +25,7 @@ define wget::fetch (
     undef   => [],
     default => [ "HTTP_PROXY=${::http_proxy}", "http_proxy=${::http_proxy}" ],
   }
-  $https_proxy_env = $::http_proxy ? {
+  $https_proxy_env = $::https_proxy ? {
     undef   => [],
     default => [ "HTTPS_PROXY=${::https_proxy}", "https_proxy=${::https_proxy}" ],
   }


### PR DESCRIPTION
when setting https_proxy, check for https_proxy fact instead of http_proxy
This was probably just a typo, but if you don't have the https_proxy fact and do have the http_proxy fact, this module will fail.
