### PR TITLE
Fixed 'unless' test when we are using caching

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -44,9 +44,10 @@ define wget::fetch (
     false => '--no-verbose'
   }
 
-  $unless_test = $redownload ? {
-    true  => 'test',
-    false => "test -s ${destination}"
+  if $redownload == true or $cache_dir != undef  {
+    $unless_test = 'test'
+  } else {
+    $unless_test = "test -s ${destination}"
   }
 
   $nocheckcert_option = $nocheckcertificate ? {


### PR DESCRIPTION
The "unless" check of wget's `exec` resource uses the existence of the destination file to determine whether or not it should fetch the remote file.  This causes problems when other resources create a different version of the file.  Consider the following scenario:
1. I use the puppetlabs-archive task to extract a Java installation from a tar file.  This creates a file called local_policy.jar in my Java directory.
2. I ask the wget module to fetch an alternate version of local_policy.jar from our web site. I want to replace the original version that came from the tar file, and I want to use caching so I don't download it every time.
3. Wget's `exec` resource checks the existence of local_policy.jar in the Java directory to see of it needs to be fetched.  Since there is already a file there, it does not download it.
4. Since caching is enabled, wget's `file` resource tries to copy the file from the cache directory into the Java directory, but since it wasn't ever downloaded, the copy fails.

When we enable caching, the wget module uses the `-N` option to conditionally download the file, so there is no need to check the destination file.  I've made a change to the `unless_test` variable to skip checking when we are using caching.  Since the file resource always runs, we get the nice benefit of making sure the file always matches the copy in the cache directory.
