### PR TITLE
Add parameter for arbitrary wget flags

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -19,6 +19,7 @@ define wget::fetch (
   $headers            = undef,
   $cache_dir          = undef,
   $cache_file         = undef,
+  $flags              = undef,
 ) {
 
   include wget
@@ -98,8 +99,13 @@ define wget::fetch (
     default => $headers_all,
   }
 
+  $flags_joined = $flags ? {
+    undef => '',
+    default => inline_template(' <%= @flags.join(" ") %>')
+  }
+
   exec { "wget-${name}":
-    command     => "wget ${verbose_option}${nocheckcert_option}${no_cookies_option}${header_option}${user_option}${output_option} '${source}'",
+    command     => "wget ${verbose_option}${nocheckcert_option}${no_cookies_option}${header_option}${user_option}${output_option}${flags_joined} '${source}'",
     timeout     => $timeout,
     unless      => $unless_test,
     environment => $environment,

--- a/spec/defines/fetch_spec.rb
+++ b/spec/defines/fetch_spec.rb
@@ -130,4 +130,15 @@ describe 'wget::fetch' do
     }) }
   end
 
+  context "with flags", :compile do
+    let(:params) { super().merge({
+      :flags => ['--flag1', '--flag2'],
+    })}
+
+    it { should contain_exec('wget-test').with({
+      'command' => "wget --no-verbose --output-document='#{destination}' --flag1 --flag2 'http://localhost/source'",
+      'environment' => []
+    }) }
+  end
+
 end


### PR DESCRIPTION
This adds support for a `flags` array that can take an arbitrary number of
wget command-line flags. Our use-case is adding the `--auth-no-challenge`
flag, which doesn't seem worth adding a dedicated parameter for. Hopefully
other users who have individual requirements can use this array to add options
to a wget request without having to work too hard.
