### PR TITLE
Fixed PE version to allow 3.2 and 3.3

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -84,7 +84,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": "3.2.x"
+      "version_requirement": ">=3.2.0 <3.4.0"
     },
     {
       "name": "puppet",


### PR DESCRIPTION
This allows this module to work on PE 3.2 and 3.3.  I excluded support for 3.4 because PE 3.4 is likely to be a major change and I'm not sure if this will work with 3.4 yet.
