### PR TITLE
Fix Ruby string error

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -144,7 +144,15 @@ define wget::fetch (
 
   # again, not using stdlib.concat, concatanate array of headers into a single string
   if $headers != undef {
-    $headers_all = inline_template('<% @headers.each do | header | -%> --header "<%= header -%>"<% end -%>')
+    $array_headers = is_array($headers) ? {
+      false => $headers ? {
+        '' => [],
+        default => split($headers, ','),
+      },
+      default => $headers,
+    }
+
+    $headers_all = inline_template('<% @array_headers.each do | header | -%> --header "<%= header -%>"<% end -%>')
   }
 
   $header_option = $headers ? {


### PR DESCRIPTION
Ruby String class no longer has each. Update to convert the headers to
an array in order to use each on them.

Signed-off-by: Wayne Porter <wporter82@gmail.com>